### PR TITLE
Visually hide "item embed" widget option

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/exhibit-sub-pages.scss
+++ b/app/assets/stylesheets/spotlight-overrides/exhibit-sub-pages.scss
@@ -317,3 +317,9 @@ form.browse-search-form {
     }
   }
 }
+
+// visually hide "item embed" button from exhibit item widgets options
+// remove this once have working
+.st-block-controls__button[data-type="solr_documents_embed"] {
+  display: none;
+}


### PR DESCRIPTION
**Visually hide "item embed" widget option**
* * *

**JIRA Ticket**:
* https://github.com/harvard-lts/CURIOSity/issues/230

# What does this Pull Request do?
Visually hides the option to select the "item embed" widget

# How should this be tested?
Part 1
* Navigate to the edit mode of the "Exhibit Item Widgets" page in the Demo exhibit ([quick link](https://localhost:21407/demo/feature/exhibit-item-widgets))
* Add a new section and look under the "Exhibit item widgets" section. You should no longer see the "Item Embed" button as an option
* If you inspect for "st-block-controls__button", you'll notice the button with data-type="solr_documents_embed" is still there, just as display:none

Part 2
* Under Appearance --> Visual Theme, switch to the "Vanilla Spotlight" theme and navigate back to the edit mode of the "Exhibit Item Widgets" page in the Demo exhibit
* You should see the "Item Embed" button as an option again (this will be useful when we do further testing to get this functionality working)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? NA
- integration tests? NA

# Interested parties
@phil-plencner-hl @dl-maura 