### PR TITLE
Hide "terms of use" exhibit card from homepage

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/site-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/site-home.scss
@@ -968,3 +968,8 @@ table#exhibit-specific-fields {
     }
   }
 }
+
+// hide terms-of-use exhibit card from homepage
+.exhibit-card-container a[href="/terms-of-use"] {
+  display: none;
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -12,7 +12,7 @@
         <nav class="hl__footer-nav" aria-label="footer 1 of 2">
           <ul class="hl__footer-nav__items">
             <li data-ga-link="Footer Links" class="hl__footer-nav__item">
-              <a href="http://curiosity.lib.harvard.edu/terms-of-use" class="hl__link-tag"><span>Terms of Use</span></a>
+              <a href="/terms-of-use" class="hl__link-tag"><span>Terms of Use</span></a>
             </li>          
             <li data-ga-link="Footer Links" class="hl__footer-nav__item">
               <a href="https://hollis.harvard.edu/" class="hl__link-tag"><span>HOLLIS</span></a>


### PR DESCRIPTION
**Hide "terms of use" exhibit card from homepage**
* * *

**JIRA Ticket**: 
* https://github.com/harvard-lts/CURIOSity/issues/52

# What does this Pull Request do?
Hide "terms of use" exhibit card from homepage, while still having access to it as a link in the footer.

# How should this be tested?
* Spin up local environment
* If don't already have one, create an exhibit called "Terms of Use" (the url link should be `terms-of-use`) and publish it
* Navigate to the homepage and look through your exhibit cards - you should notice that the "terms of use" exhibit card does not appear
* Scroll down to the footer and click on the "Terms of Use" link - you should be directed to the terms of use exhibit page

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? NA
- integration tests? NA

# Interested parties
@phil-plencner-hl @dl-maura 