### PR TITLE
Updating oaipmh gem to use beta.14.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'delayed_job_web'
 
 # bring in the Harvard Harvesting gem, commented out version is used for development.
 # do not build with the second version uncommented.
-gem 'spotlight-oaipmh-resources', git: 'https://github.com/harvard-lts/spotlight-oaipmh-resources', tag: 'v3.0.0-beta.13'
+gem 'spotlight-oaipmh-resources', git: 'https://github.com/harvard-lts/spotlight-oaipmh-resources', tag: 'v3.0.0-beta.14'
 # gem 'spotlight-oaipmh-resources', path: 'vendor/spotlight-oaipmh-resources'
 
 gem 'rails-healthcheck'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/harvard-lts/spotlight-oaipmh-resources
-  revision: af405a458cc3dd18d69312d14ee85dc0cc140bd8
-  tag: v3.0.0-beta.13
+  revision: 2d66ac81674593907ac0e9611a4f47fe2a9a00b0
+  tag: v3.0.0-beta.14
   specs:
-    spotlight-oaipmh-resources (3.0.0.pre.beta.13)
+    spotlight-oaipmh-resources (3.0.0.pre.beta.14)
       mods
       oai
 
@@ -316,7 +316,7 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
-    iso-639 (0.3.5)
+    iso-639 (0.3.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)


### PR DESCRIPTION
**Upgrades Spotlight Oaipmh Resources Gem to 3.0.0.beta.14**
* * *

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

- 3.0.0 Beta 14: https://github.com/harvard-lts/spotlight-oaipmh-resources/releases/tag/v3.0.0-beta.14
- Spotlight Oaipmh PR: https://github.com/harvard-lts/spotlight-oaipmh-resources/pull/49

# What does this Pull Request do?

This PR does 2 things:

- bumps the SOLR_ROW count variable to 1000 to speed up solr harvest per Anthony
- changes the Set name labels to Set Spec (per Vanessa)

To test, you'll need to pull this branch and spin up your local. You should see the label Set Spec on the Item harvest page. Then you can harvest a solr collection (I'd suggest scats-calendars as it is the smallest) to confirm my change didn't break anything.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@dl-maura 