### PR TITLE
Add new checkbox to hide exhibits from homepage.

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/site-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/site-home.scss
@@ -971,8 +971,3 @@ table#exhibit-specific-fields {
     }
   }
 }
-
-// hide terms-of-use exhibit card from homepage
-.exhibit-card-container a[href="/terms-of-use"] {
-  display: none;
-}

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -12,7 +12,7 @@ module Spotlight
     load_and_authorize_resource
 
     def index
-      @published_exhibits = @exhibits.includes(:thumbnail).published.ordered_by_weight.page(params[:page])
+      @published_exhibits = @exhibits.includes(:thumbnail).published.show_homepage.ordered_by_weight.page(params[:page])
       @published_exhibits = @published_exhibits.tagged_with(params[:tag]) if params[:tag]
       if @exhibits.one?
         redirect_to @exhibits.first, flash: flash.to_h
@@ -97,6 +97,7 @@ module Spotlight
         :published,
         :tag_list,
         :set_name,
+        :hide_homepage,
         contact_emails_attributes: %i[id email],
         languages_attributes: %i[id public]
       )

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'mail'
+module Spotlight
+  ##
+  # Spotlight exhibit
+  class Exhibit < ActiveRecord::Base
+    class_attribute :themes_selector
+    include Spotlight::ExhibitAnalytics
+    include Spotlight::ExhibitDefaults
+    include Spotlight::ExhibitDocuments
+    include Spotlight::Translatables
+
+    translates :title, :subtitle, :description
+
+    has_paper_trail
+
+    scope :published, -> { where(published: true) }
+    scope :unpublished, -> { where(published: false) }
+    scope :show_homepage, -> {where.not(hide_homepage: true).or(where(hide_homepage: nil)) }
+    scope :ordered_by_weight, -> { order('weight ASC') }
+
+    paginates_per 48
+
+    extend FriendlyId
+    friendly_id :title, use: %i[slugged finders] do |config|
+      config.reserved_words&.concat(%w[site])
+    end
+
+    validates :title, presence: true, if: -> { I18n.locale == I18n.default_locale }
+    validates :slug, uniqueness: true
+    validates :theme, inclusion: { in: Spotlight::Engine.config.exhibit_themes }, allow_blank: true
+
+    after_validation :move_friendly_id_error_to_slug
+
+    acts_as_tagger
+    acts_as_taggable
+    delegate :blacklight_config, to: :blacklight_configuration
+    serialize :facets, Array
+
+    # NOTE: friendly id associations need to be 'destroy'ed to reap the slug history
+    has_many :about_pages, -> { for_default_locale }, extend: FriendlyId::FinderMethods
+    has_many :attachments, dependent: :destroy
+    has_many :contact_emails, dependent: :delete_all # These are the contacts who get "Contact us" emails
+    has_many :contacts, dependent: :delete_all # These are the contacts who appear in the sidebar
+    has_many :custom_fields, dependent: :delete_all do
+      def as_strong_params
+        multivalued_params, single_valued_params = writeable.partition(&:is_multiple?)
+        single_valued_params.pluck(:slug, :field).flatten +
+          [multivalued_params.each_with_object({}) do |f, h|
+            h[f.slug] = []
+            h[f.field] = []
+          end]
+      end
+    end
+    has_many :custom_search_fields, dependent: :delete_all
+
+    has_many :feature_pages, -> { for_default_locale }, extend: FriendlyId::FinderMethods
+    has_many :groups, dependent: :delete_all
+    has_many :job_trackers, as: :on, dependent: :delete_all
+    has_many :bulk_updates, dependent: :delete_all
+    has_many :main_navigations, dependent: :delete_all
+    has_many :resources
+    has_many :roles, as: :resource, dependent: :delete_all
+    has_many :searches, dependent: :destroy, extend: FriendlyId::FinderMethods
+    has_many :solr_document_sidecars, dependent: :delete_all
+    has_many :users, through: :roles, class_name: Spotlight::Engine.config.user_class
+
+    has_many :pages, dependent: :destroy
+    has_many :filters, dependent: :delete_all
+    has_many :translations, class_name: 'I18n::Backend::ActiveRecord::Translation', dependent: :destroy, inverse_of: :exhibit
+    has_many :languages, dependent: :destroy
+
+    has_one :blacklight_configuration, class_name: 'Spotlight::BlacklightConfiguration', dependent: :delete
+    has_one :home_page, -> { for_default_locale }
+
+    belongs_to :site, optional: true
+    belongs_to :masthead, dependent: :destroy, optional: true
+    belongs_to :thumbnail, class_name: 'Spotlight::ExhibitThumbnail', dependent: :destroy, optional: true
+
+    accepts_nested_attributes_for :about_pages, :attachments, :contacts, :custom_fields, :feature_pages, :groups, :languages,
+                                  :main_navigations, :owned_taggings, :pages, :resources, :searches, :solr_document_sidecars, :translations
+    accepts_nested_attributes_for :blacklight_configuration, :home_page, :filters, update_only: true
+    accepts_nested_attributes_for :masthead, :thumbnail, update_only: true, reject_if: proc { |attr| attr['iiif_tilesource'].blank? }
+    accepts_nested_attributes_for :contact_emails, reject_if: proc { |attr| attr['email'].blank? }
+    accepts_nested_attributes_for :roles, allow_destroy: true, reject_if: proc { |attr| attr['user_key'].blank? && attr['id'].blank? }
+
+    before_save :sanitize_description, if: :description_changed?
+
+    def main_about_page
+      @main_about_page ||= about_pages.for_locale.published.first
+    end
+
+    def browse_categories?
+      searches.published.any?
+    end
+
+    def themes
+      @themes ||= begin
+        return Spotlight::Engine.config.exhibit_themes unless self.class.themes_selector
+
+        self.class.themes_selector.call(self)
+      end
+    end
+
+    def to_s
+      title
+    end
+
+    def import(hash)
+      ActiveRecord::Base.transaction do
+        Spotlight::ExhibitImportExportService.new(self).from_hash!(hash)
+        save
+      end
+    end
+
+    def solr_data
+      filters.each_with_object({}) do |filter, hash|
+        hash.merge! filter.to_hash
+      end
+    end
+
+    def reindex_later(current_user = nil)
+      Spotlight::ReindexExhibitJob.perform_later(self, user: current_user)
+    end
+
+    def uploaded_resource_fields
+      Spotlight::Engine.config.upload_fields
+    end
+
+    def searchable?
+      blacklight_config.search_fields.any? { |_k, v| v.enabled && v.include_in_simple_select != false }
+    end
+
+    def requested_by
+      roles.first&.user
+    end
+
+    def reindex_progress
+      @reindex_progress ||= BackgroundJobProgress.new(self, job_class: Spotlight::ReindexExhibitJob)
+    end
+
+    def available_locales
+      @available_locales ||= languages.pluck(:locale)
+    end
+
+    protected
+
+    def sanitize_description
+      self.description = ::Rails::Html::FullSanitizer.new.sanitize(description)
+    end
+
+    private
+
+    def move_friendly_id_error_to_slug
+      errors.add :slug, *errors.delete(:friendly_id) if errors[:friendly_id].present?
+    end
+  end
+end

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -20,6 +20,11 @@
     <%= f.check_box :published, label: "" %>
     <small class="form-text text-muted"><%= t(:'.fields.published.help_block') %></small>
   <% end %>
+  <%= f.form_group :hide_homepage, label: { text: t('exhibit.hide_homepage'), class: 'pt-0' }, help: nil do %>
+    <%= f.check_box :hide_homepage, label: t('exhibit.hide_homepage') %>
+    <small class="form-text text-muted"><%= t('exhibit.hide_homepage_helper') %></small>
+  <% end %>
+
 
   <div class="form-actions">
 

--- a/app/views/spotlight/sites/_exhibit.html.erb
+++ b/app/views/spotlight/sites/_exhibit.html.erb
@@ -1,0 +1,19 @@
+<% exhibit = f.object %>
+<tr class="dd-item dd3-item" data-id="<%= exhibit.id %>">
+  <td>
+     <div class="handle-wrap">
+       <div class="dd-handle dd3-handle"><%= t :drag %></div>
+
+       <%= f.hidden_field :id %>
+       <%= f.hidden_field :weight, data: { property: "weight" } %>
+
+       <%= link_to exhibit.title, exhibit %>
+     </div>
+
+  </td>
+  <td class="text-right"><%= exhibit.published? ? t(:'.published') : t(:'.unpublished') %></td>
+  <td class="text-right"><%= exhibit.hide_homepage? ? t(:'.hidden') : t(:'.displayed') %></td>
+  <td class="text-right"><%= exhibit.requested_by %></td>
+  <td class="text-right"><%= l exhibit.created_at, format: :long %></td>
+  <td class="text-right"><%= l exhibit.updated_at, format: :long %></td>
+</tr>

--- a/app/views/spotlight/sites/edit_exhibits.html.erb
+++ b/app/views/spotlight/sites/edit_exhibits.html.erb
@@ -1,0 +1,32 @@
+<%= page_title(t('.page_title')) %>
+<%= bootstrap_form_for @site, url: spotlight.site_path, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
+  <p class="instructions"><%= t :'.instructions' %></p>
+  <table class="table table-striped dd-table">
+    <thead>
+      <tr>
+        <th><%= Spotlight::Exhibit.human_attribute_name(:title) %></th>
+        <th class="text-right"><%= Spotlight::Exhibit.human_attribute_name(:published)  %></th>
+        <th class="text-right"><%= Spotlight::Exhibit.human_attribute_name(:homepage)  %></th>
+        <th class="text-right"><%= Spotlight::Exhibit.human_attribute_name(:requested_by) %></th>
+        <th class="text-right"><%= Spotlight::Exhibit.human_attribute_name(:created_at)  %></th>
+        <th class="text-right"><%= Spotlight::Exhibit.human_attribute_name(:updated_at)  %></th>
+      </tr>
+    </thead>
+    <tbody class="table metadata_fields dd dd-list" data-behavior="nestable" data-max-depth="1" data-list-node-name="tbody" data-item-node-name="tr" data-expand-btn-HTML=" " data-collapse-btn-HTML=" ">
+      <%= f.fields_for :exhibits do |exhibit_form| %>
+        <%= render partial: 'exhibit', locals: { f: exhibit_form } %>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>
+
+<% content_for(:sidebar_position) { 'order-last' } %>
+<% content_for(:sidebar) do %>
+  <%= render 'shared/site_sidebar' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@
 en:
   exhibit:
     set_name: 'FTS set name'
+    hide_homepage: 'Hide on Homepage?'
+    hide_homepage_helper: 'Check this box to hide the exhibit on the CURIOSity homepage. The exhibit can still be viewed via URL.'
   full_text_search:
     facets:
       not_available: 'Limiters not available while searching inside text of items'

--- a/db/migrate/20221212200520_add_hide_homepage_to_exhibits.rb
+++ b/db/migrate/20221212200520_add_hide_homepage_to_exhibits.rb
@@ -1,0 +1,5 @@
+class AddHideHomepageToExhibits < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spotlight_exhibits, :hide_homepage, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_18_232843) do
+ActiveRecord::Schema.define(version: 2022_12_12_200520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 2022_10_18_232843) do
     t.integer "site_id"
     t.string "theme"
     t.string "set_name"
+    t.boolean "hide_homepage"
     t.index ["masthead_id"], name: "index_spotlight_exhibits_on_masthead_id"
     t.index ["site_id"], name: "index_spotlight_exhibits_on_site_id"
     t.index ["slug"], name: "index_spotlight_exhibits_on_slug", unique: true


### PR DESCRIPTION
**Add new checkbox to hide exhibits from homepage.**
* * *

**JIRA Ticket**: [(52)](https://github.com/harvard-lts/CURIOSity/issues/52)

# What does this Pull Request do?
Adds a new checkbox to the general exhibit form "Hide on Homepage?". If you check the box it does not display the exhibit card on the CURIOSity homepage, but you can still get to the exhibit via URL.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container. Make sure the migrations run.
* See all your exhibits display on the homepage.
* Edit an exhibit and check the box for "Hide on Homepage?" 
* The exhibit no longer displays on the homepage. It still shows up under "Your exhibits" if you are the admin. 
* The exhibit that is no longer on the homepage is still accessible by going to the URL.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@dl-maura 