### PR TITLE
Add default fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,6 +50,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'place-of-origin_ssim', label: I18n.t(:'spotlight.search.fields.facet.place-of-origin_ssim'), limit: true
     config.add_facet_field 'publisher_ssim', label: I18n.t(:'spotlight.search.fields.facet.publisher_ssim'), limit: true
     config.add_facet_field 'date_ssim', label: I18n.t(:'spotlight.search.fields.facet.date_ssim'), limit: true
+    config.add_facet_field 'normalized-date_ssim', label: I18n.t(:'spotlight.search.fields.facet.normalized-date_ssim'), limit: true
     config.add_facet_field 'language_ssim', label: I18n.t(:'spotlight.search.fields.facet.language_ssim'), limit: true
     config.add_facet_field 'genre_ssim', label: I18n.t(:'spotlight.search.fields.facet.genre_ssim'), limit: true
     config.add_facet_field 'culture_ssim', label: I18n.t(:'spotlight.search.fields.facet.culture_ssim'), limit: true

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -91,6 +91,10 @@ Spotlight::Engine.config.upload_fields = [
     label: -> { I18n.t(:'spotlight.search.fields.date_tesim') }
   ),
   Spotlight::UploadFieldConfig.new(
+    field_name: :'normalized-date_ssim',
+    label: -> { I18n.t(:'spotlight.search.fields.normalized-date_ssim') }
+  ),  
+  Spotlight::UploadFieldConfig.new(
     field_name: :date_ssim,
     label: -> { I18n.t(:'spotlight.search.fields.date_ssim') }
   ),
@@ -206,6 +210,11 @@ Spotlight::Engine.config.upload_fields = [
     label: -> { I18n.t(:'spotlight.search.fields.note_tesim') }
   ),
   Spotlight::UploadFieldConfig.new(
+    field_name: :'biographical-historical-note_tesim',
+    blacklight_options: { if: false },
+    label: -> { I18n.t(:'spotlight.search.fields.biographical-historical-note_tesim') }
+  ),  
+  Spotlight::UploadFieldConfig.new(
     field_name: :'cite-as_tesim',
     label: -> { I18n.t(:'spotlight.search.fields.cite-as_tesim') }
   ),
@@ -217,6 +226,11 @@ Spotlight::Engine.config.upload_fields = [
     field_name: :container_tesim,
     label: -> { I18n.t(:'spotlight.search.fields.container_tesim') }
   ),
+  Spotlight::UploadFieldConfig.new(
+    field_name: :'unit-id_tesim',
+    blacklight_options: { if: false },
+    label: -> { I18n.t(:'spotlight.search.fields.unit-id_tesim') }
+  ),  
   Spotlight::UploadFieldConfig.new(
     field_name: :series_tesim,
     blacklight_options: { if: false },

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -211,7 +211,6 @@ Spotlight::Engine.config.upload_fields = [
   ),
   Spotlight::UploadFieldConfig.new(
     field_name: :'biographical-historical-note_tesim',
-    blacklight_options: { if: false },
     label: -> { I18n.t(:'spotlight.search.fields.biographical-historical-note_tesim') }
   ),  
   Spotlight::UploadFieldConfig.new(
@@ -228,7 +227,6 @@ Spotlight::Engine.config.upload_fields = [
   ),
   Spotlight::UploadFieldConfig.new(
     field_name: :'unit-id_tesim',
-    blacklight_options: { if: false },
     label: -> { I18n.t(:'spotlight.search.fields.unit-id_tesim') }
   ),  
   Spotlight::UploadFieldConfig.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
         attribution_tesim: 'Attribution'
         available-to_ssim: 'Available To'
         available-to_tesim: 'Available To'
+        biographical-historical-note_tesim: 'Biographical / Historical Note'
         cite-as_tesim: 'Cite As'
         classification_tesim: 'Classification'
         collection_ssim: 'Collection'
@@ -87,6 +88,7 @@ en:
         manifest_url_ssm: 'Manifest Url'
         materials-techniques_ssim: 'Materials / Techniques'
         materials-techniques_tesim: 'Materials / Techniques'
+        normalized-date_ssim: 'Normalized Date'
         note_tesim: 'Notes'
         permalink-dcp_ssim: 'Harvard Digital Collections'
         permalink-dcp_tesim: 'Harvard Digital Collections'
@@ -112,6 +114,7 @@ en:
         subjects_tesim: 'Subject'
         thumbnail_url_ssm: 'Thumbnail Url'
         unique-id_tesim: 'Unique Id'
+        unit-id_tesim: 'Identifier'
         urn_ssi: 'URN'
         exhibit_tags: 'Curator Tags'
         facet:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
           collection_ssim: 'Collection'
           language_ssim: 'Language'
           materials-techniques_ssim: 'Material / Technique'
+          normalized-date_ssim: 'Normalized Date'
           place-of-origin_ssim: 'Place of Origin'
           places_ssim: 'Place'
           publisher_ssim: 'Publisher'

--- a/lib/spotlight_exhibit_decorator_default_field_config.json
+++ b/lib/spotlight_exhibit_decorator_default_field_config.json
@@ -27,6 +27,13 @@
       "slideshow": false,
       "show": true
     },
+    "normalized-date_ssim": {
+      "list": true,
+      "gallery": false,
+      "masonry": false,
+      "slideshow": false,
+      "show": true
+    },    
     "publisher_ssim": {
       "list": true,
       "gallery": false,
@@ -139,6 +146,13 @@
       "slideshow": false,
       "show": true
     },
+    "biographical-historical-note_tesim": {
+      "list": false,
+      "gallery": false,
+      "masonry": false,
+      "slideshow": false,
+      "show": true
+    },    
     "cite-as_tesim": {
       "list": false,
       "gallery": false,
@@ -160,6 +174,13 @@
       "slideshow": false,
       "show": true
     },
+    "unit-id_tesim": {
+      "list": false,
+      "gallery": false,
+      "masonry": false,
+      "slideshow": false,
+      "show": true
+    },     
     "series_ssim": {
       "list": false,
       "gallery": false,

--- a/lib/spotlight_exhibit_decorator_default_field_config.json
+++ b/lib/spotlight_exhibit_decorator_default_field_config.json
@@ -28,11 +28,11 @@
       "show": true
     },
     "normalized-date_ssim": {
-      "list": true,
+      "list": false,
       "gallery": false,
       "masonry": false,
       "slideshow": false,
-      "show": true
+      "show": false
     },    
     "publisher_ssim": {
       "list": true,


### PR DESCRIPTION
**Add default fields**
* * *

**JIRA Ticket**: [(#231)](https://github.com/harvard-lts/CURIOSity/issues/231)

# What does this Pull Request do?
Adds the default fields as described in Issue 231

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the `add-default-fields` branch
* Manually create a new exhibit
* Confirm that the new fields and facets appear as described in issue 231

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No
