### PR TITLE
Adding tags and bulk_update to masked user abilities.

### DIFF
--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -58,7 +58,7 @@ module Spotlight
 
       if (user.is_masked?)
         can :read, Spotlight::Language
-        can [:read, :curate], Spotlight::Exhibit
+        can [:read, :curate, :tag, :bulk_update], Spotlight::Exhibit
         can :read, Spotlight::JobTracker
       else
         can :read, Spotlight::Language, exhibit_id: user.exhibit_roles.pluck(:resource_id)


### PR DESCRIPTION
**Adding tags and bulk_update to masked user abilities.**
* * *

**JIRA Ticket**: [(#261)](https://github.com/harvard-lts/CURIOSity/issues/261)

# What does this Pull Request do?
This allows people who are masked as Curators or Exhibit Admins to be able to modify Tags and do Bulk Updates.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the application using the `fix-mask` branch
* Login as a user who is a site admin
* On the homepage, toggle the "View as" dropdown to be either "Curator" or "Exhibit Admin"
* Go to an exhibit and then go to the exhibit dashboard
* Confirm you can modify Tags and perform Bulk Updates.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No