### PR TITLE
Using spotlight-oaipmh-resources 3.0.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'delayed_job_web'
 
 # bring in the Harvard Harvesting gem, commented out version is used for development.
 # do not build with the second version uncommented.
-gem 'spotlight-oaipmh-resources', git: 'https://github.com/harvard-lts/spotlight-oaipmh-resources', tag: 'v3.0.0-beta.14'
+gem 'spotlight-oaipmh-resources', git: 'https://github.com/harvard-lts/spotlight-oaipmh-resources', tag: 'v3.0.0'
 # gem 'spotlight-oaipmh-resources', path: 'vendor/spotlight-oaipmh-resources'
 
 gem 'rails-healthcheck'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/harvard-lts/spotlight-oaipmh-resources
-  revision: 2d66ac81674593907ac0e9611a4f47fe2a9a00b0
-  tag: v3.0.0-beta.14
+  revision: 534ed9f8ba63405aecfbd6677d3db635ef7c993f
+  tag: v3.0.0
   specs:
-    spotlight-oaipmh-resources (3.0.0.pre.beta.14)
+    spotlight-oaipmh-resources (3.0.0)
       mods
       oai
 


### PR DESCRIPTION
**Using spotlight-oaipmh-resources 3.0.0.**
* * *

# What does this Pull Request do?
This updates the Gemfile to use spotlight-oaipmh-resources 3.0.0, since we are officially out of beta.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the `gem-version-3` branch
* sh into the container: `docker exec -it harvard-curiosity-web-1 sh`
* Confirm version 3.0.0 of the gem is installed: `bundle list` should show: `spotlight-oaipmh-resources (3.0.0 534ed9f)`
* Harvest an exhibit to confirm it is still working properly.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No