### PR TITLE
Moving min-width search button style out of Safari exception.

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
@@ -165,6 +165,7 @@
       padding: 6px 12px 6px 0;
       background: $white;
       border: none;
+      min-width: 120px; 
       &::before {
         content: "";
         padding-left: 12px;
@@ -186,13 +187,8 @@
         color: $gray-600;
       }
     }
-    /* search button override for Safari 11+ */
-    @media not all and (min-resolution:.001dpcm) { 
-        button#search { 
-        min-width: 120px; 
-        }
-    }
-    // full text helper box
+
+     // full text helper box
     .fulltext-helper-text {
       color: $white;
       font-family: "Trueno", sans-serif;

--- a/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
@@ -187,8 +187,7 @@
         color: $gray-600;
       }
     }
-
-     // full text helper box
+    // full text helper box
     .fulltext-helper-text {
       color: $white;
       font-family: "Trueno", sans-serif;


### PR DESCRIPTION
**Moving min-width search button style out of Safari exception.*
* * *

# What does this Pull Request do?
Moves the arrow for the search box up to one line for Safari (and all other browsers?).


# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container in the `fix-safari-16` branch
* Go to exhibits in Safari browser
* Confirm the arrow in the search button is on the same line as the rest of the button.
* Confirm still looks good in your other browsers.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No