### PR TITLE
Remove query string from documentId if it exists.

### DIFF
--- a/app/views/catalog/_tools_and_links.html.erb
+++ b/app/views/catalog/_tools_and_links.html.erb
@@ -98,7 +98,9 @@
                 //TODO: make it so the dropdown menu stays open if the click did not result
                 function testRangeBoundariesAndLinkToPrintPDF(){
                   const maxPage = <%=number_of_pages%>;
-                  let documentId = <%= delivery_service[1]%>;
+                  // Some Ids have a query string after them such as 457731773?n=2. 
+                  // We remove that with the split.
+                  let documentId = <%= delivery_service[1].split('?')[0]%>;
                   let validateEmail = function(email) {
                     var re = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
                     return re.test(email);

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_12_200520) do
+ActiveRecord::Schema.define(version: 2022_12_19_205026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2022_12_12_200520) do
     t.string "metadata_type"
     t.string "type", null: false
     t.string "solr_mapping_file"
+    t.string "filter"
     t.index ["exhibit_id"], name: "index_spotlight_harvesters_on_exhibit_id"
     t.index ["user_id"], name: "index_spotlight_harvesters_on_user_id"
   end


### PR DESCRIPTION
**Remove query string from documentId if it exists.**
* * *

**JIRA Ticket**: [#272](https://github.com/harvard-lts/CURIOSity/issues/272)

# What does this Pull Request do?
For some objects, the download functionality is broken. This is because sometimes the documentId has a query string in it like this example: https://localhost:21407/botanical-illustrations/catalog/62-ARN00007C00002

The documentID looks like this:  `457731773?n=2`

This commit just lops off the `?` and everything after it if it exists in the documentID. Objects download correctly after this change.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the application off of the `fix-download` branch
* Harvest the Botanical Illustrations exhibit if you have not already done so.
* Go to this item: https://localhost:21407/botanical-illustrations/catalog/62-ARN00007C00002
* Confirm that the download button works properly.
* Go to another item, such as this one in the Demo exhibit: https://localhost:21407/demo/catalog/47-990014631980203941
* Confirm that the download button works properly.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@dl-maura 