### PR TITLE
Adding toggle for Link To Search in Metadata configuration.

### DIFF
--- a/app/controllers/spotlight/metadata_configurations_controller.rb
+++ b/app/controllers/spotlight/metadata_configurations_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Spotlight
+    ##
+    # CRUD actions for Blacklight metadata fields (e.g. index/show fields for
+    # various view types)
+    class MetadataConfigurationsController < Spotlight::ApplicationController
+      before_action :authenticate_user!
+      load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
+      load_and_authorize_resource :blacklight_configuration, through: :exhibit, singleton: true, parent: false
+  
+      def show
+        respond_to do |format|
+          format.json do
+            render json: @blacklight_configuration.blacklight_config.index_fields.as_json
+          end
+        end
+      end
+  
+      def edit
+        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit
+        add_breadcrumb t(:'spotlight.configuration.sidebar.header'), exhibit_dashboard_path(@exhibit)
+        add_breadcrumb t(:'spotlight.configuration.sidebar.metadata'), edit_exhibit_metadata_configuration_path(@exhibit)
+      end
+  
+      def update
+        if @blacklight_configuration.update(exhibit_params)
+          flash[:notice] = t(:'helpers.submit.blacklight_configuration.updated', model: @blacklight_configuration.class.model_name.human.downcase)
+          redirect_to edit_exhibit_metadata_configuration_path(@exhibit)
+        else
+          render action: 'edit'
+        end
+      end
+  
+      private
+  
+      def exhibit_params
+        params.require(:blacklight_configuration).permit(
+          index_fields: [exhibit_configuration_index_params]
+        )
+      end
+  
+      def exhibit_configuration_index_params
+        views = @blacklight_configuration.default_blacklight_config.view.keys | [:show]
+  
+        @blacklight_configuration.blacklight_config.index_fields.keys.index_with do |_element|
+          (%i[enabled label weight link_to_facet] | views)
+        end
+      end
+    end
+  end
+  

--- a/app/presenters/rtl_show_presenter.rb
+++ b/app/presenters/rtl_show_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class RTLShowPresenter < ::Blacklight::ShowPresenter
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::UrlHelper
+    include ActionView::Helpers::SanitizeHelper
+    include ActionView::Context
+  
+    def field_value_separator
+      tag.br
+    end
+  
+    def html_title
+      super.split(/<\/li><li.*?>/).map(&:html_safe).join(", ").gsub(/<.*?>/, "")
+    end
+  
+    def field_config(field)
+      super.tap do |f|
+        f.separator_options =
+          {
+            words_connector: field_value_separator,
+            two_words_connector: field_value_separator,
+            last_word_connector: field_value_separator
+          }
+      end
+    end
+  end
+  

--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -1,0 +1,18 @@
+<tr data-id="<%= key.parameterize %>" class="dd-item">
+  <%= f.fields_for key do |field| %>
+    <td>
+      <%= field.hidden_field :weight, 'data-property' => 'weight' %>
+      <div class="handle-wrap" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
+        <div class="dd-handle dd3-handle"><%= t :drag %></div>
+        <a href="#edit-in-place" class="field-label edit-in-place"><%= config.display_label %></a>
+        <%= field.hidden_field :label, value: config.display_label, class: 'form-control input-sm', data: {:"edit-field-target" => 'true'} %>
+      </div>
+    </td>
+    <td class="checkbox-cell text-center"><%= field.check_box :show, inline: true, checked: config.show, hide_label: true %></td>
+    <% available_view_fields.keys.each do |type| %>
+      <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), hide_label: true %></td>
+    <% end %>
+    <% # Customized - add link to facet option %>
+    <td class="checkbox-cell text-center"><%= field.check_box :link_to_facet, {inline: true, checked: config.link_to_facet.present?, hide_label: true}, config.key, false %></td>
+  <% end %>
+</tr>

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -30,6 +30,10 @@
               <%= select_deselect_button %>
             </th>
           <% end %>
+          <th class="text-center">
+            <div>Link to Search</div>
+            <%= select_deselect_button %>
+          </th>
         </tr>
       </thead>
       <tbody class="metadata_fields dd dd-list" data-behavior="nestable" data-max-depth="1" data-list-node-name="tbody" data-item-node-name="tr" data-expand-btn-HTML=" " data-collapse-btn-HTML=" ">


### PR DESCRIPTION
**Adding toggle for Link To Search in Metadata configuration.**
* * *

**JIRA Ticket**: [#245](https://github.com/harvard-lts/CURIOSity/issues/245)

Other Relevant Links (Mailing list discussion, related pull requests, etc.)
* Princeton's solution: https://github.com/pulibrary/dpul/pull/623 

# What does this Pull Request do?
This adds a new series of check boxes to the metadata configuration page for "Link to Search". Checking the box for the metadata field displays a link to the facet on the detail pages of the exhibit. This is based off of Princeton's solution that I linked above.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the `link-facetable` branch
* Edit the metadata on one of the exhibits. For the demo exhibit: https://localhost:21407/demo/metadata_configuration/edit
* Check boxes in the column for "Link to search" and press the "Save Changes" button.
* Confirm that the boxes you checked remain selected.
* Confirm that the fields of the boxes you checked are displaying links to the faceted search on the front-end of the exhibit.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@dl-maura 