### PR TITLE
Use redis in dev mode

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,7 @@
 development:
-  adapter: async
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { sprintf "redis://%s%s:%s/1", (ENV['REDIS_PASSWORD'].present? ? ":#{ENV['REDIS_PASSWORD']}@" : ''), ENV.fetch('REDIS_HOST', 'localhost'), ENV.fetch('REDIS_PORT', '6379') } %>
+  channel_prefix: CURIOSity_development
 
 test:
   adapter: test


### PR DESCRIPTION
**Use redis even when running in dev**
* * *


# What does this Pull Request do?
Redis needs to be on in dev mode for replication in docker swarm.

# How should this be tested?

Spin up locally, log in, be able to use the site. You won't see any difference in behavior

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties