### PR TITLE
Remove Guests from "Add a New User" dropdown on Exhibit User Configuration form.

### DIFF
--- a/app/views/spotlight/roles/_edit_fields.html.erb
+++ b/app/views/spotlight/roles/_edit_fields.html.erb
@@ -1,7 +1,7 @@
         <tr data-edit-for="<%= f.object.new_record? ? 'new' : f.object.id %>">
-        <td>
-          <%= f.select :user_key, User.where(guest: false).pluck(:email), hide_label: true, disabled: f.object.persisted?, help: (t('.help') if f.object.new_record?) %>
-        </td>
-        <td><%= f.select :role, roles_for_select, hide_label: true %></td>
-        <td></td>
+          <td>
+            <%= f.select :user_key, User.where(guest: false).pluck(:email), hide_label: true, disabled: f.object.persisted?, help: (t('.help') if f.object.new_record?) %>
+          </td>
+          <td><%= f.select :role, roles_for_select, hide_label: true %></td>
+          <td></td>
         </tr>

--- a/app/views/spotlight/roles/_edit_fields.html.erb
+++ b/app/views/spotlight/roles/_edit_fields.html.erb
@@ -1,7 +1,7 @@
         <tr data-edit-for="<%= f.object.new_record? ? 'new' : f.object.id %>">
-          <td>
-            <%= f.select :user_key, User.pluck(:email), hide_label: true, disabled: f.object.persisted?, help: (t('.help') if f.object.new_record?) %>
-          </td>
-          <td><%= f.select :role, roles_for_select, hide_label: true %></td>
-          <td></td>
+        <td>
+          <%= f.select :user_key, User.where(guest: false).pluck(:email), hide_label: true, disabled: f.object.persisted?, help: (t('.help') if f.object.new_record?) %>
+        </td>
+        <td><%= f.select :role, roles_for_select, hide_label: true %></td>
+        <td></td>
         </tr>


### PR DESCRIPTION
**Remove Guests from "Add a New User" dropdown on Exhibit User Configuration form.**
* * *


# What does this Pull Request do?
On production we are seeing a lot of guest users from `devise_guest` showing up on the "Add a New User" drop down of the Exhibit User Configuration form. 
For example:
![UnwantedGuests](https://user-images.githubusercontent.com/40801910/214141594-e8553156-2dcf-428a-a648-e635a6a9e945.jpg)

This PR removes guests from the drop-down.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the `remove-guests` branch
* Shell into the Postgres container: `docker exec -it harvard-curiosity-postgres-1 sh` 
* Login to psql: `psql -d spotlight -U spotlight_user`
* Query the data in your users table: `select email,guest from users;`
* Update at least one user to be a guest if none exist. For example: `update users set guest=true where email='support@notch8.com';`
* Login as an administrator to CURIOSity and go to an exhibit's User Configuration page. For example: https://localhost:21407/demo/users
* Click on the "Add A New User" button
* Confirm that the users that are marked as guest in the psql table do not display in the email address drop-down that appears.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No