### PR TITLE
Command updated to db migrate and clear guests and old searches

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -33,7 +33,7 @@ services:
       - .env
     entrypoint: ["sh", "-c"]
     command:
-      - bin/db-wait.sh postgres:5432 sh -c "bundle exec rake db:migrate && echo 'migrated' && bundle exec rake devise_guests:delete_old_guest_users[7] && echo 'deleted guests' && bundle exec rake blacklight:delete_old_searches[7] && echo 'old searches deleted'"
+      - bin/db-wait.sh postgres:5432 sh -c "bundle exec rake db:migrate && echo 'migrated' && bundle exec rake devise_guests:delete_old_guest_users[7] && echo 'deleted guests' && sleep 1d"
     depends_on:
       - postgres
     volumes:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -33,7 +33,7 @@ services:
       - .env
     entrypoint: ["sh", "-c"]
     command:
-      - bin/db-wait.sh postgres:5432 bundle exec rake db:migrate
+      - bin/db-wait.sh postgres:5432 sh -c "bundle exec rake db:migrate && echo 'migrated' && bundle exec rake devise_guests:delete_old_guest_users && echo 'deleted guests' && bundle exec rake blacklight:delete_old_searches[7] && echo 'old searches deleted'"
     depends_on:
       - postgres
     volumes:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -33,7 +33,7 @@ services:
       - .env
     entrypoint: ["sh", "-c"]
     command:
-      - bin/db-wait.sh postgres:5432 sh -c "bundle exec rake db:migrate && echo 'migrated' && bundle exec rake devise_guests:delete_old_guest_users && echo 'deleted guests' && bundle exec rake blacklight:delete_old_searches[7] && echo 'old searches deleted'"
+      - bin/db-wait.sh postgres:5432 sh -c "bundle exec rake db:migrate && echo 'migrated' && bundle exec rake devise_guests:delete_old_guest_users[7] && echo 'deleted guests' && bundle exec rake blacklight:delete_old_searches[7] && echo 'old searches deleted'"
     depends_on:
       - postgres
     volumes:


### PR DESCRIPTION
**DB Migrate also clears guests and old searches**
* * *

# What does this Pull Request do?
W don't want to keep guests forever, so this will have the db migrate container clear them and guest searches in addition to running db migrate

# How should this be tested?

Pre-work: You'll want to have some guests in your db. I would suggest making an older user a guest and then also making a brand new user who is also a guest.

Pull and build this branch, making sure you overwrite the override you have locally (either just taking the new command or just replacing the file, depending on if you made other local changes). Spin up using the standard method, and watch the logs for db migrate -- you should see echoes like:
2023-01-24 11:08:42 migrated
2023-01-24 11:09:00 deleted guests
2023-01-24 11:09:12 old searches deleted

You can then exec into your local db container and select all users who are guests 

select email,guest from users where guest=true;

The older user who you made a guest should be gone if it was created more than 7 days ago but the NEW user should still be there (as it has not been 7 days).

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties